### PR TITLE
Fix plushangup not being recognized.

### DIFF
--- a/src/iwar-engine.c
+++ b/src/iwar-engine.c
@@ -1113,12 +1113,12 @@ int main(int argc,  char **argv)
                     beepflag=true;
                 }
 
-            if (!strcmp(iwar_option, "PlusHangup"))
+            if (!strcmp(iwar_option, "plushangup"))
                 {
                     plushang=true;
                 }
 
-            if (!strcmp(iwar_option, "PlusHangupsleep"))
+            if (!strcmp(iwar_option, "plushangupsleep"))
                 {
                     strlcpy(tmp, iwar_value, sizeof(tmp));
                     PlusHangupsleep=atoi(tmp);


### PR DESCRIPTION
The iwar.conf file that comes with iwar sets two options called "plushangup" and "plushangupsleep". The old version of the code checked for "PlusHangup" and "PlusHangupsleep". This change brings the name of the options in line with the others. You could also modify the provided iwar.conf if you'd prefer.